### PR TITLE
fix directory name 

### DIFF
--- a/data_tools/ava/obtain_video_resolution.sh
+++ b/data_tools/ava/obtain_video_resolution.sh
@@ -2,9 +2,9 @@
 
 cd ../../data/ava/
 
-ls ./video_trimmed_trainval | while read filename; do \
+ls ./videos_trimmed_trainval | while read filename; do \
   vid="$(echo ${filename} | cut -d'.' -f1)";
-  resolution=`ffprobe -v error -select_streams v:0 -show_entries stream=width,height -of csv=s=x:p=0 ./video_trimmed_trainval/${filename}`
+  resolution=`ffprobe -v error -select_streams v:0 -show_entries stream=width,height -of csv=s=x:p=0 ./videos_trimmed_trainval/${filename}`
   echo ${vid} ${resolution}
 done &> ava_video_resolution_stats.csv
 


### PR DESCRIPTION
When we download and preprocess ava data, we execute preprocess_videos.sh. At this time, videos_trimmed_trainval directory is created. However, executing obtain_video_resolution.sh causes an error because the directory name does not match.

Sol) data_tools/ava/obtain_video_resolution.sh
video_trimmed_trainval -> videos_trimmed_trainval