### PR TITLE
fix img type error, videotype

### DIFF
--- a/mmaction/datasets/video_dataset.py
+++ b/mmaction/datasets/video_dataset.py
@@ -186,7 +186,7 @@ class VideoDataset(Dataset):
 
     def _load_image(self, video_reader, directory, modality, idx):
         if modality in ['RGB', 'RGBDiff']:
-            return [video_reader[idx - 1]]
+            return [video_reader[idx - 1].asnumpy()]
         elif modality == 'Flow':
             raise NotImplementedError
         else:


### PR DESCRIPTION
I use pip install decord, and load kinetics400 data with videodataset class. but there are img type error, 

  File "/home/ziming/anaconda3/envs/pytorch_py36/lib/python3.6/site-packages/torch/utils/data/_utils/worker.py", line 178, in _worker_loop
    data = fetcher.fetch(index)
  File "/home/ziming/anaconda3/envs/pytorch_py36/lib/python3.6/site-packages/torch/utils/data/_utils/fetch.py", line 44, in fetch
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/home/ziming/anaconda3/envs/pytorch_py36/lib/python3.6/site-packages/torch/utils/data/_utils/fetch.py", line 44, in <listcomp>
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/home/ziming/bitaction/mmaction/datasets/video_dataset.py", line 366, in __getitem__
    is_flow=True if modality == 'Flow' else False)
  File "/home/ziming/bitaction/mmaction/datasets/transforms.py", line 429, in __call__
    img, scale, return_scale=True) for img in img_group]
  File "/home/ziming/bitaction/mmaction/datasets/transforms.py", line 429, in <listcomp>
    img, scale, return_scale=True) for img in img_group]
  File "/home/ziming/mmcv/mmcv/image/transforms/resize.py", line 104, in imrescale
    rescaled_img = imresize(img, new_size, interpolation=interpolation)
  File "/home/ziming/mmcv/mmcv/image/transforms/resize.py", line 46, in imresize
    img, size, interpolation=interp_codes[interpolation])
TypeError: Expected Ptr<cv::UMat> for argument 'src'

Finally, I think it's because the function def _load_image() didn't transfer the img into "ndarray" type, so the img can't be transformed by  OpenCV.  




